### PR TITLE
Adds a new output to be used to set up CloudWatch alarms

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -170,7 +170,12 @@ output "zone_id" {
   value = "${aws_alb.main.zone_id}"
 }
 
-// The target-group id of the ALB
+// The target-group ids of this ALB
 output "target_groups" {
   value = [ "${aws_alb_target_group.main.*.id}" ]
+}
+
+// The target-group arn_suffixs of this ALB
+output "target_groups_suffixes" {
+  value = [ "${aws_alb_target_group.main.*.arn_suffix}" ]
 }


### PR DESCRIPTION
The output can be used as an input when setting alarms.

We can also parse the arn and extract the suffix from there. But this is harmless and easier