### PR TITLE
200 is no longer a default for matcher

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -84,6 +84,7 @@ resource "aws_alb_target_group" "main" {
     timeout             = 5
     path                = "${var.healthcheckpaths[count.index]}"
     interval            = 30
+    matcher             = 200
   }
 }
 


### PR DESCRIPTION
This is needed because of [this](https://github.com/terraform-providers/terraform-provider-aws/issues/2327) bug in aws provider 1.3.X