### PR TITLE
Fixes wrong output

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -161,11 +161,6 @@ output "dns" {
   value = "${aws_alb.main.dns_name}"
 }
 
-// FQDN built using the zone domain and name
-output "fqdn" {
-  value = "${aws_route53_record.main.fqdn}"
-}
-
 // The zone id of the ALB
 output "zone_id" {
   value = "${aws_alb.main.zone_id}"


### PR DESCRIPTION
The resource referenced by this output use a `count` attribute so, it will fail if we don't use a splat notation